### PR TITLE
Introducing Apex test wire adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,51 @@ There are two flavors of test adapters available: LDS and generic. Both allow te
 /**
  * Registers a wire adapter that mimics Lightning Data Service (LDS) adapters behavior,
  * and emitted data and error shapes. For example, the emitted shape is
- * `{ data: object|undefined, error: FetchResponse|undefined}`
+ * `{ data: object|undefined, error: FetchResponse|undefined}`.
  */
 registerLdsTestWireAdapter(identifier: any): LdsTestWireAdapter;
 
 interface LdsTestWireAdapter {
+    /** Emits data. */
+    emit(value: object): void;
+
+    /**
+     * Emits an error. By default this will emit a resource not found error.
+     *
+     * `{
+     *       ok: false,
+     *       status: 404,
+     *       statusText: "NOT_FOUND",
+     *       body: [{
+     *           errorCode: "NOT_FOUND",
+     *           message: "The requested resource does not exist",
+     *       }]
+     *  }`
+     */
+    error(body?: any, status?: number, statusText?: string): void;
+
+    /**
+     * Gets the last resolved config. Useful if component @wire uses includes
+     * dynamic parameters.
+     */
+    getLastConfig(): object;
+}
+
+interface FetchResponse {
+    body: any,
+    ok: false,
+    status: number,
+    statusText: string,
+}
+
+/**
+ * Registers a wire adapter that connects to an Apex method and provides APIs
+ * to emit data and errors in the expected shape. For example, the emitted shape
+ * is `{ data: object|undefined, error: FetchResponse|undefined}`.
+ */
+registerApexTestWireAdapter(identifier: any): ApexTestWireAdapter;
+
+interface ApexTestWireAdapter {
     /** Emits data. */
     emit(value: object): void;
 

--- a/README.md
+++ b/README.md
@@ -118,12 +118,11 @@ interface ApexTestWireAdapter {
      *
      * `{
      *       ok: false,
-     *       status: 404,
-     *       statusText: "NOT_FOUND",
-     *       body: [{
-     *           errorCode: "NOT_FOUND",
-     *           message: "The requested resource does not exist",
-     *       }]
+     *       status: 400,
+     *       statusText: "Bad Request",
+     *       body: {
+     *           message: "An internal server error has occurred",
+     *       }
      *  }`
      */
     error(body?: any, status?: number, statusText?: string): void;

--- a/src/adapters/apex.js
+++ b/src/adapters/apex.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { register, ValueChangedEvent } from '@lwc/wire-service';
+
+export default function createAdapter(adapterId) {
+    let done = false;
+    let lastConfig;
+    const wiredEventTargets = [];
+
+    const emit = (value) => {
+        if (!done) {
+            wiredEventTargets.forEach(wiredEventTarget => wiredEventTarget.dispatchEvent(new ValueChangedEvent({ data: value, error: undefined })));
+        }
+    };
+
+    const error = (body, status, statusText) => {
+        if (!done) {
+            done = true;
+
+            if (status && (status < 400 || status > 599)) {
+                throw new Error("'status' must be >= 400 or <= 599");
+            }
+
+            body = body || {
+                message: 'An internal server error has occurred',
+            };
+
+            status = status || 400;
+
+            statusText = statusText || 'Bad Request';
+
+            const err = {
+                body,
+                ok: false,
+                status,
+                statusText,
+            };
+
+            wiredEventTargets.forEach(wiredEventTarget => wiredEventTarget.dispatchEvent(new ValueChangedEvent({ data: undefined, error: err })));
+        }
+    };
+
+    const getLastConfig = () => {
+        return lastConfig;
+    };
+
+    const add = (arr, item) => {
+        const idx = arr.indexOf(item);
+        if (idx === -1) {
+            arr.push(item);
+        }
+    };
+
+    register(adapterId, (wiredEventTarget) => {
+        done = false;
+        add(wiredEventTargets, wiredEventTarget);
+        wiredEventTarget.dispatchEvent(new ValueChangedEvent({ data: undefined, error: undefined }));
+
+        wiredEventTarget.addEventListener('connect', () => {
+            done = false;
+            lastConfig = {};
+            add(wiredEventTargets, wiredEventTarget);
+        });
+
+        wiredEventTarget.addEventListener('disconnect', () => {
+            done = true;
+            lastConfig = undefined;
+            const idx = wiredEventTargets.indexOf(wiredEventTarget);
+            if (idx > -1) {
+                wiredEventTargets.splice(idx, 1);
+            }
+        });
+
+        wiredEventTarget.addEventListener('config', (newConfig) => {
+            lastConfig = newConfig;
+        });
+    });
+
+    return {
+        emit,
+        error,
+        getLastConfig
+    };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { register } from '@lwc/engine';
 import { registerWireService } from '@lwc/wire-service';
 import createLdsAdapter from './adapters/lds';
 import createGenericAdapter from './adapters/generic';
+import createApexAdapter from './adapters/apex';
 
 let registered = false;
 
@@ -29,6 +30,16 @@ function registerLdsTestWireAdapter(identifier) {
     return createLdsAdapter(identifier);
 }
 
+function registerApexTestWireAdapter(identifier) {
+    if (!identifier) {
+        throw new Error('No adapter specified');
+    }
+
+    ensureWireServiceRegistered();
+
+    return createApexAdapter(identifier);
+}
+
 function registerTestWireAdapter(identifier) {
     if (!identifier) {
         throw new Error('No adapter specified');
@@ -41,5 +52,6 @@ function registerTestWireAdapter(identifier) {
 
 export {
     registerLdsTestWireAdapter,
+    registerApexTestWireAdapter,
     registerTestWireAdapter,
 };


### PR DESCRIPTION
Similar to LDS wire adapters, data and errors that come down the wire for Apex methods follow a specific data shape. This PR introducing a new API, `registerApexTestWireAdapter`, that provides APIs to emit data and errors through the wire service for Apex methods. 

Most interestingly, the errors emitted through this new test adapter have a certain shape with a reasonable default (defaults can be overridden):

```
{
    ok: false,
    status: 400,
    statusText: "Bad Request",
    body: {
        message: "An internal server error has occurred",
     }
}
```
