### PR TITLE
chore: update `lwc.modules` field to latest supported format

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,12 @@
     "rollup": "0.50.0"
   },
   "lwc": {
-    "modules": {
-      "wire-service-jest-util": "dist/wire-service-jest-util.es.js"
-    }
+    "modules": [
+      {
+        "name": "wire-service-jest-util",
+        "path": "dist/wire-service-jest-util.es.js"
+      }
+    ]
   },
   "resolutions": {
     "js-yaml": "^3.13.1"


### PR DESCRIPTION
Updated to follow the new format supported by @lwc/module-resolver:
https://github.com/salesforce/lwc/pull/1414