### PR TITLE
fix: move deps to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
         "@lwc/synthetic-shadow": "^7.1.3",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-typescript": "^11.1.6",
+        "@types/jest": "^29.5.12",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
         "eslint": "^8.53.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^28.2.0",
@@ -68,8 +71,5 @@
         "yarn": "1.22.22"
     },
     "dependencies": {
-        "@types/jest": "^29.5.12",
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
-        "@typescript-eslint/parser": "^6.21.0"
     }
 }


### PR DESCRIPTION
These dependencies are not actually required for `@salesforce/wire-service-jest-util` to function. They should be devDeps, not deps.