### PR TITLE
chore: fix publish script

### DIFF
--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const execa = require('execa');
+const { execaSync } = require('execa');
 const isCI = require('is-ci');
 
 const ARGS = [
@@ -18,20 +18,16 @@ const ARGS = [
     '--registry=https://registry.npmjs.org',
 ];
 
-const { stderr, stdin, stdout } = process;
-
 if (!isCI) {
     console.error('This script is only meant to run in CI.');
     process.exit(1);
 }
 
 try {
-    execa.sync('npm', ARGS, {
+    execaSync('npm', ARGS, {
         // Prioritize locally installed binaries (node_modules/.bin)
         preferLocal: true,
-        stderr,
-        stdin,
-        stdout,
+        stdio: 'inherit',
     });
 } catch (ex) {
     console.error(ex);


### PR DESCRIPTION
The publish script is borked because of execa major version bump in #118 and causes the NPM deployment to fail.

It looks like release 4.1.5 didn't go through the CI to deploy, it was most likely done manually.

Looks like execa dropped support for commonJS in v6 but we're able to use it now because [node v24 has better interopt support for ESM modules ](https://nodejs.org/docs/latest-v24.x/api/modules.html#loading-ecmascript-modules-using-require)